### PR TITLE
Let the user set the font for the headers

### DIFF
--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -2,9 +2,9 @@ $blockquote: $type-border !default;
 $sans: "Dosis", "Helvetica Neue", Arial, sans-serif !default;
 $serif: "Exo", Georgia, Times, "Times New Roman", serif !default;
 $mono: "Inconsolata", Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace !default;
-$heading-font-family: $serif;
-$header-title-font-family: $sans;
-$header-subtitle-font-family: $mono;
+$heading-font-family: $serif !default;
+$header-title-font-family: $sans !default;
+$header-subtitle-font-family: $mono !default;
 
 // Fonts
 .heading {


### PR DESCRIPTION
Add the `!default` flag to the value of `$head*` in _typography.scss

This allows the user to set the fonts for the blog header and the post title by editing `sass/custom/_fonts.scss`
