### PR TITLE
GitHub JSONP not actually supplying a callback name

### DIFF
--- a/source/javascripts/github.js
+++ b/source/javascripts/github.js
@@ -13,15 +13,15 @@ var github = (function(){
   return {
     showRepos: function(options){
       $.ajax({
-          url: "https://api.github.com/users/"+options.user+"/repos?sort=pushed&callback=?"
-        , dataType: 'jsonp'
+          url: "https://api.github.com/users/"+options.user+"/repos?sort=pushed"
+        , dataType: 'json'
         , error: function (err) { $(options.target + ' li.loading').addClass('error').text("Error loading feed"); }
         , success: function(data) {
           var repos = [];
-          if (!data || !data.data) { return; }
-          for (var i = 0; i < data.data.length; i++) {
-            if (options.skip_forks && data.data[i].fork) { continue; }
-            repos.push(data.data[i]);
+          if (!data ) { return; }
+          for (var i = 0; i < data.length; i++) {
+            if (options.skip_forks && data[i].fork) { continue; }
+            repos.push(data[i]);
           }
           if (options.count) { repos.splice(options.count); }
           render(options.target, repos);


### PR DESCRIPTION
Thanks for the theme!

With a clean fork / clone, my GitHub repos weren't displaying correctly.

It seems like JSONP isn't actually required, so I changed this to a simple async JSON call.
